### PR TITLE
Enable continuous image puller.

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -1,4 +1,7 @@
 jupyterhub:
+  prePuller:
+    continuous:
+      enabled: true
   scheduling:
     userScheduler:
       enabled: true


### PR DESCRIPTION
Addresses probable issue behind https://github.com/berkeley-dsep-infra/data100-19s/issues/34.