### PR TITLE
Remove decimal from memory limit.

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -6,7 +6,7 @@ jupyterhub:
   singleuser:
     memory:
       guarantee: 768M
-      limit: 1.5G
+      limit: 1536M
     image:
       name: docker.io/berkeleydsep/singleuser-data100
   auth:


### PR DESCRIPTION
Test pod's limit and guarantee were 2G when 1.5G specified.