### PR TITLE
Turn off hook pre-puller

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -5,6 +5,8 @@ jupyterhub:
   prePuller:
     continuous:
       enabled: true
+    hook:
+      enabled: false
   cull:
     enabled: false
   scheduling:


### PR DESCRIPTION
Was consistently failing, with:

2019/01/28 20:34:05 10 of 0 nodes currently has the required images.
2019/01/28 20:34:07 10 of 2 nodes currently has the required images.
2019/01/28 20:34:09 10 of 3 nodes currently has the required images.
2019/01/28 20:34:11 10 of 3 nodes currently has the required images.
2019/01/28 20:34:13 10 of 3 nodes currently has the required images.
2019/01/28 20:34:15 10 of 3 nodes currently has the required images.
2019/01/28 20:34:17 10 of 3 nodes currently has the required images.
2019/01/28 20:34:20 10 of 3 nodes currently has the required images.
2019/01/28 20:34:22 10 of 3 nodes currently has the required images.
2019/01/28 20:34:24 10 of 3 nodes currently has the required images.
2019/01/28 20:34:26 10 of 3 nodes currently has the required images.
2019/01/28 20:34:28 10 of 3 nodes currently has the required images.
2019/01/28 20:34:30 10 of 3 nodes currently has the required images.
2019/01/28 20:34:32 10 of 3 nodes currently has the required images.
2019/01/28 20:34:34 10 of 3 nodes currently has the required images.
2019/01/28 20:34:36 10 of 3 nodes currently has the required images.
2019/01/28 20:34:38 10 of 3 nodes currently has the required images.
2019/01/28 20:34:40 10 of 3 nodes currently has the required images.
2019/01/28 20:34:42 10 of 3 nodes currently has the required images.
2019/01/28 20:34:44 10 of 3 nodes currently has the required images.