### PR TITLE
Revert "Bump jassign and revert nbconvert"

### DIFF
--- a/deployments/data100/image/environment.yml
+++ b/deployments/data100/image/environment.yml
@@ -30,7 +30,7 @@ dependencies:
 - lxml=4.1.1
 - matplotlib=3.0.1
 - mistune=0.8.3
-- nbconvert=4.3.0
+- nbconvert=5.4.0
 - nbformat=4.4.0
 - networkx=2.0
 - nodejs=10.13.0
@@ -92,7 +92,7 @@ dependencies:
   - psycopg2==2.7.6.1
   - jupyterhub==0.9.2
   - nbserverproxy==0.8.8
-  - jassign==0.0.6
+  - jassign==0.0.5
   - okpy==1.13.11
   - tqdm==4.29.1
 


### PR DESCRIPTION
https://circleci.com/gh/berkeley-dsep-infra/data100-19s/88
fails with
```
 ---> Running in 1ac1d9bfca14
Solving environment: ...working... failed

ResolvePackageNotFound:
  - nbconvert=4.3.0
```

This reverts commit af0b70c650ca701de0980b51796d672b06390987.