### PR TITLE
Change nbconvert version + bump jassign

### DIFF
--- a/deployments/data100/image/environment.yml
+++ b/deployments/data100/image/environment.yml
@@ -91,7 +91,7 @@ dependencies:
   - psycopg2==2.7.6.1
   - jupyterhub==0.9.2
   - nbserverproxy==0.8.8
-  - jassign==0.0.5
+  - jassign==0.0.6
   - okpy==1.13.11
   - tqdm==4.29.1
   - nbconvert=4.3.0

--- a/deployments/data100/image/environment.yml
+++ b/deployments/data100/image/environment.yml
@@ -30,7 +30,6 @@ dependencies:
 - lxml=4.1.1
 - matplotlib=3.0.1
 - mistune=0.8.3
-- nbconvert=5.4.0
 - nbformat=4.4.0
 - networkx=2.0
 - nodejs=10.13.0
@@ -95,4 +94,5 @@ dependencies:
   - jassign==0.0.5
   - okpy==1.13.11
   - tqdm==4.29.1
+  - nbconvert=4.3.0
 

--- a/deployments/data100/image/environment.yml
+++ b/deployments/data100/image/environment.yml
@@ -94,5 +94,5 @@ dependencies:
   - jassign==0.0.6
   - okpy==1.13.11
   - tqdm==4.29.1
-  - nbconvert=4.3.0
+  - nbconvert==4.3.0
 


### PR DESCRIPTION
Undoes https://github.com/berkeley-dsep-infra/data100-19s/pull/54

nbconvert was failing because versions in PyPI weren't in conda.