### PR TITLE
Try modifying env variable of hub directly

### DIFF
--- a/deployments/data100/config/common.yaml
+++ b/deployments/data100/config/common.yaml
@@ -1,10 +1,5 @@
 jupyterhub:
   hub:
-    # AKS by default sets the k8s master host to a public hostname,
-    # that is fronted by AWS LB. This causes read timeouts frequently.
-    # Attempt to work around this with https://github.com/jupyterhub/kubespawner/issues/282
-    extraEnv:
-      KUBERNETES_SERVICE_HOST: kubernetes.default.svc.cluster.local
     db:
       pvc:
         storageClassName: managed-premium

--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -65,6 +65,13 @@ jupyterhub:
       02-lab-availability: |
         c.Spawner.cmd = ['jupyter-labhub']
 
+      # AKS by default sets the k8s master host to a public hostname,
+      # that is fronted by AWS LB. This causes read timeouts frequently.
+      # Attempt to work around this with https://github.com/jupyterhub/kubespawner/issues/282
+      03-aks-local: |
+        import os
+        os.environ['KUBERNETES_SERVICE_HOST'] = 'kubernetes.default.svc.cluster.local'
+
 homeDirectories:
   nfs:
     serverPath: "/homes"


### PR DESCRIPTION
Injecting KUBERNETES_SERVICE_HOST from deployment doesn't
work, since it is overriden by the service injector for the pod.